### PR TITLE
add momentum optimizer and test FP32 AMP PureFP16

### DIFF
--- a/benchmark/bert/run_glue_amp.sh
+++ b/benchmark/bert/run_glue_amp.sh
@@ -1,0 +1,17 @@
+export CUDA_VISIBLE_DEVICES=0
+export TASK_NAME=SST-2
+
+python -u ./run_glue.py \
+    --model_type bert \
+    --model_name_or_path bert-base-uncased \
+    --task_name $TASK_NAME \
+    --max_seq_length 128 \
+    --batch_size 64   \
+    --learning_rate 2e-5 \
+    --num_train_epochs 3 \
+    --logging_steps 100 \
+    --save_steps 500 \
+    --output_dir ./tmp/$TASK_NAME/ \
+    --use_amp true \
+    --scale_loss 128.0 \
+    --use_dynamic_loss_scaling true \

--- a/benchmark/bert/run_glue_fp32.sh
+++ b/benchmark/bert/run_glue_fp32.sh
@@ -1,0 +1,15 @@
+export CUDA_VISIBLE_DEVICES=0
+export TASK_NAME=SST-2
+
+python -u ./run_glue.py \
+    --model_type bert \
+    --model_name_or_path bert-base-uncased \
+    --task_name $TASK_NAME \
+    --max_seq_length 128 \
+    --batch_size 64   \
+    --learning_rate 2e-5 \
+    --num_train_epochs 3 \
+    --logging_steps 100 \
+    --save_steps 500 \
+    --output_dir ./tmp/$TASK_NAME/ \
+

--- a/benchmark/bert/run_glue_pure_fp16.sh
+++ b/benchmark/bert/run_glue_pure_fp16.sh
@@ -1,0 +1,16 @@
+export CUDA_VISIBLE_DEVICES=0
+export TASK_NAME=SST-2
+
+python -u ./run_glue.py \
+    --model_type bert \
+    --model_name_or_path bert-base-uncased \
+    --task_name $TASK_NAME \
+    --max_seq_length 128 \
+    --batch_size 64   \
+    --learning_rate 2e-5 \
+    --num_train_epochs 3 \
+    --logging_steps 100 \
+    --save_steps 500 \
+    --output_dir ./tmp/$TASK_NAME/ \
+    --use_pure_fp16 true \
+    --multi_precision true

--- a/paddlenlp/data/batchify.py
+++ b/paddlenlp/data/batchify.py
@@ -92,11 +92,12 @@ class Pad(object):
                 [8. 2. 0. 0.]]
             '''
      """
-    def __init__(self, pad_val=0, axis=0, ret_length=None, dtype=None):
+    def __init__(self, pad_val=0, axis=0, ret_length=None, dtype=None, use_tensor_core=False):
         self._pad_val = pad_val
         self._axis = axis
         self._ret_length = ret_length
         self._dtype = dtype
+        self._use_tensor_core = use_tensor_core
 
     def __call__(self, data):
         """
@@ -116,6 +117,8 @@ class Pad(object):
         arrs = [np.asarray(ele) for ele in data]
         original_length = [ele.shape[self._axis] for ele in arrs]
         max_size = max(original_length)
+        if self._use_tensor_core and max_size % 8 != 0:
+            max_size = (int(max_size / 8) + 1) * 8
         ret_shape = list(arrs[0].shape)
         ret_shape[self._axis] = max_size
         ret_shape = (len(arrs), ) + tuple(ret_shape)

--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -271,7 +271,8 @@ class BertModel(BertPretrainedModel):
                 input_ids,
                 token_type_ids=None,
                 position_ids=None,
-                attention_mask=None):
+                attention_mask=None,
+                use_pure_fp16=False):
         if attention_mask is None:
             attention_mask = paddle.unsqueeze(
                 (input_ids == self.pad_token_id
@@ -281,6 +282,9 @@ class BertModel(BertPretrainedModel):
             input_ids=input_ids,
             position_ids=position_ids,
             token_type_ids=token_type_ids)
+        if use_pure_fp16:
+            attention_mask = paddle.cast(attention_mask, "float16")
+            embedding_output = paddle.cast(embedding_output, "float16")
         encoder_outputs = self.encoder(embedding_output, attention_mask)
         sequence_output = encoder_outputs
         pooled_output = self.pooler(sequence_output)
@@ -333,12 +337,14 @@ class BertForSequenceClassification(BertPretrainedModel):
                 input_ids,
                 token_type_ids=None,
                 position_ids=None,
-                attention_mask=None):
+                attention_mask=None,
+                use_pure_fp16=False):
         _, pooled_output = self.bert(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
-            attention_mask=attention_mask)
+            attention_mask=attention_mask,
+            use_pure_fp16=use_pure_fp16)
 
         pooled_output = self.dropout(pooled_output)
         logits = self.classifier(pooled_output)


### PR DESCRIPTION
In Bert SST-2 finetune task:

- change `AdamW` optimizer to `Momentum` optimizer ( for using `multi_precision` in Pure Fp16 training)

- use `run_glue_fp32.sh`, `run_glue_amp.sh`, `run_glue_pure_fp16.sh` to run `FP32`, `AMP` or `Pure FP16` version.

- you may need to use `cast` if it occurs `LayerNorm` or `matmul` dtype ERROR
